### PR TITLE
Fix warnings after quitting the app

### DIFF
--- a/src/Gifup.vala
+++ b/src/Gifup.vala
@@ -12,6 +12,8 @@ namespace Gifup {
         
         public override void activate () {
             window = new Window ();
+            window.set_application (this);
+            window.show_all ();
         }
 
         public static int main (string [] args) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -3,7 +3,7 @@ using Gtk;
 public string selected_dir;
 
 namespace Gifup {
-    class Window : Gtk.Window {
+    class Window : Gtk.ApplicationWindow {
         // Init all UI elements
         private Gtk.Grid grid;
         private AdvanceOptions grid_advance;
@@ -30,11 +30,6 @@ namespace Gifup {
             this.set_titlebar (headerbar);
 
             build_ui();
-
-            this.destroy.connect ( Gtk.main_quit );
-            show_all();
-
-            Gtk.main ();
         }
 
         void build_ui () {


### PR DESCRIPTION
I get the following warnings every time after closing the app window:

```
(com.github.bharatkalluri.gifup:8132): GLib-GObject-CRITICAL **: 22:11:39.583: g_object_ref_sink: assertion 'G_IS_OBJECT (object)' failed

(com.github.bharatkalluri.gifup:8132): GLib-GObject-CRITICAL **: 22:11:39.587: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```

Investigating with gdb shows that `activate` method in `src/Gifup.vala` is called even after destroying the app window:

```
(gdb) bt
#0  0x00007ffff6c14ea1 in  () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#1  0x00007ffff6c161eb in g_logv () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007ffff6c1633f in g_log () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007ffff6ef34bc in g_object_ref_sink () at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#4  0x0000555555556bd0 in gifup_gifup_app_real_activate (base=0x5555557790f0) at ../src/Gifup.vala:14
#5  0x00007ffff6eea10d in g_closure_invoke () at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#6  0x00007ffff6efcde8 in  () at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#7  0x00007ffff6f05715 in g_signal_emit_valist () at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#8  0x00007ffff6f0612f in g_signal_emit () at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#9  0x00007ffff71d0b95 in  () at /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0
#10 0x00007ffff71d0da6 in g_application_run () at /usr/lib/x86_64-linux-gnu/libgio-2.0.so.0
#11 0x0000555555556c58 in gifup_gifup_app_main (args=0x7fffffffdcf8, args_length1=1) at ../src/Gifup.vala:19
```

This PR fixes these warnings by using `Gtk.ApplicationWindow`.
