### PR TITLE
deb-packaging: Sort dependencies alphabetically

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,10 +2,9 @@ Source: com.github.bharatkalluri.gifup
 Section: x11
 Priority: extra
 Maintainer: Bharat Kalluri <kalluribharat@gmail.com>
-Build-Depends: meson (>= 0.40),
+Build-Depends: debhelper (>= 9),
                libgtk-3-dev,
-               debhelper (>= 9),
-               libgtk-3-dev,
+               meson (>= 0.40),
                valac (>= 0.26)
 Standards-Version: 4.14
 


### PR DESCRIPTION
It's a kind of nitpicking though :sweat_smile:

## Changes Summary
* Sort dependencies alphabetically
* Remove unnecessary duplicated `libgtk-3-dev` from dependencies
